### PR TITLE
Cache invalidation

### DIFF
--- a/SDK/Python/sensorcloud/cache.py
+++ b/SDK/Python/sensorcloud/cache.py
@@ -126,6 +126,22 @@ class Cache(object):
         self._data['token'] = value
 
     @property
+    def auth_server(self):
+        return self._data.get('auth_server', None)
+    
+    @auth_server.setter
+    def auth_server(self, value):
+        self._data['auth_server'] = value
+
+    @property
+    def device_id(self):
+        return self._data.get('device_id', None)
+    
+    @device_id.setter
+    def device_id(self, value):
+        self._data['device_id'] = value
+
+    @property
     def sensors(self):
         if 'sensors' not in self._data:
             self._data['sensors'] = {}
@@ -138,6 +154,9 @@ class Cache(object):
             self._data['sensors'][name] = {}
 
         return SensorCache(self, name, self._data['sensors'][name])
+    
+    def reset(self):
+        self._data = {}
 
     def save(self):
         with open(self._path, 'wb') as f:

--- a/SDK/Python/sensorcloud/device.py
+++ b/SDK/Python/sensorcloud/device.py
@@ -26,9 +26,14 @@ class Device(object):
         self._requests = SensorCloudRequests(device_id, device_key, auth_server, requests = request_factory, cache = self._cache)
         self._sensors = {}
         if self._cache:
+            if self._cache.auth_server == auth_server and self._cache.device_id == device_id:
+                self._requests._authToken = self._cache.token
+                self._requests._apiServer = self._cache.server
 
-            self._requests._authToken = self._cache.token
-            self._requests._apiServer = self._cache.server
+            else:
+                self._cache.reset()
+                self._cache.auth_server = auth_server
+                self._cache.device_id = device_id
 
             for sensorCache in self._cache.sensors:
                 self._sensors[sensorCache.name] = Sensor(self, sensorCache.name, sensorCache)

--- a/SDK/Python/test/test_device.py
+++ b/SDK/Python/test/test_device.py
@@ -33,3 +33,11 @@ class CacheTests(unittest.TestCase):
         dev = sensorcloud.Device("my_device2", "some_key", "https://my.new.server", cache_file=self.cache_path)
         self.assertEqual(dev._requests._authToken, None)
         self.assertEqual(dev._requests._apiServer, None)
+
+    def test_cache_saved(self):
+        dev = sensorcloud.Device("my_device2", "some_key", "https://my.new.server", cache_file=self.cache_path)
+        dev.save_cache()
+
+        cache = sensorcloud.cache.Cache(self.cache_path)
+        self.assertEqual(cache.auth_server, "https://my.new.server")
+        self.assertEqual(cache.device_id, "my_device2")

--- a/SDK/Python/test/test_device.py
+++ b/SDK/Python/test/test_device.py
@@ -41,3 +41,5 @@ class CacheTests(unittest.TestCase):
         cache = sensorcloud.cache.Cache(self.cache_path)
         self.assertEqual(cache.auth_server, "https://my.new.server")
         self.assertEqual(cache.device_id, "my_device2")
+        self.assertEqual(cache.token, None)
+        self.assertEqual(cache.server, None)

--- a/SDK/Python/test/test_device.py
+++ b/SDK/Python/test/test_device.py
@@ -1,0 +1,35 @@
+import unittest
+import tempfile
+import os
+import shutil
+
+import sensorcloud
+
+class CacheTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp_path = tempfile.mkdtemp()
+        self.cache_path = os.path.join(self.tmp_path, "test_cache.json")
+        cache = sensorcloud.cache.Cache(self.cache_path)
+        cache.auth_server = sensorcloud.device.DEFAULT_AUTH_SERVER
+        cache.device_id = "my_device"
+        cache.server = "https://mdx.sensorcloud.microstrain.com"
+        cache.token = "lasjdflajfdlasgjlasgf"
+        cache.save()
+    
+    def tearDown(self):
+        shutil.rmtree(self.tmp_path)
+
+    def test_valid_cache(self):
+        dev = sensorcloud.Device("my_device", "some_key", cache_file=self.cache_path)
+        self.assertEqual(dev._requests._authToken, "lasjdflajfdlasgjlasgf")
+        self.assertEqual(dev._requests._apiServer, "https://mdx.sensorcloud.microstrain.com")
+
+    def test_invalid_cache_by_device_name(self):
+        dev = sensorcloud.Device("my_device2", "some_key", cache_file=self.cache_path)
+        self.assertEqual(dev._requests._authToken, None)
+        self.assertEqual(dev._requests._apiServer, None)
+
+    def test_invalid_cache_by_auth_server(self):
+        dev = sensorcloud.Device("my_device2", "some_key", "https://my.new.server", cache_file=self.cache_path)
+        self.assertEqual(dev._requests._authToken, None)
+        self.assertEqual(dev._requests._apiServer, None)


### PR DESCRIPTION
Sensorcloud cache now keeps track of the auth server and device id and invalidates the cache if they don't match.

Testing:

- Added some unit tests to test the cache
  - Run with python2 from SDK/Python `python -m unittest test.test_device`
- Tested on a WSDA and verified that swapping auth urls invalidates the cache